### PR TITLE
Fix DAT registration: APPLICATION_ID read as Integer instead of String

### DIFF
--- a/samples/CameraAccessAndroid/app/src/main/AndroidManifest.xml
+++ b/samples/CameraAccessAndroid/app/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
         <!-- Without Developer Mode, this key will need to be set with ID from app registered in Wearables Developer Center -->
         <meta-data
             android:name="com.meta.wearable.mwdat.APPLICATION_ID"
-            android:value="0"
+            android:value="@string/mwdat_application_id"
             />
 
         <activity

--- a/samples/CameraAccessAndroid/app/src/main/res/values/strings.xml
+++ b/samples/CameraAccessAndroid/app/src/main/res/values/strings.xml
@@ -48,6 +48,9 @@
     <string name="has_captured_image" description="Has captured image">Has captured image</string>
     <string name="no_captured_image" description="No captured image">No captured image</string>
 
+    <!-- Meta Wearables DAT SDK -->
+    <string name="mwdat_application_id" translatable="false">0</string>
+
     <!-- Getting Started Sheet -->
     <string name="getting_started_title" description="Getting Started sheet title">Getting started</string>
     <string name="getting_started_tip_permission" description="Tip about camera permission">First, Camera Access needs permission to use your glasses camera.</string>


### PR DESCRIPTION
## Summary

- Fix `APPLICATION_ID` meta-data in `AndroidManifest.xml` being interpreted as `Integer` instead of `String` by Android's Bundle, causing the Meta Wearables DAT SDK to receive `null` and fail the registration deep link to Meta Stella
- Use a string resource reference (`@string/mwdat_application_id`) instead of an inline numeric literal to force the correct type

Fixes #13

## Root Cause

```
W/Bundle: Key com.meta.wearable.mwdat.APPLICATION_ID expected String
          but value was a java.lang.Integer. The default value <null> was returned.
```

When `android:value="0"` is used in a `<meta-data>` tag, Android parses it as an `Integer`. The DAT SDK calls `Bundle.getString()` which returns `null` for non-String types, breaking the registration flow.

## Changes

- **`strings.xml`**: Added `<string name="mwdat_application_id" translatable="false">0</string>`
- **`AndroidManifest.xml`**: Changed `android:value="0"` to `android:value="@string/mwdat_application_id"`

## Test plan

- [x] Build and deploy to Xiaomi device (Android 12+)
- [x] Click "Connect my glasses" — Meta Stella opens DAT registration screen correctly (no more error dialog)
- [x] Verified logcat no longer shows the `Integer` type mismatch warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)