### PR TITLE
feat(android): add Quick Settings tile for one-tap VisionClaw stream start

### DIFF
--- a/samples/CameraAccessAndroid/app/src/main/AndroidManifest.xml
+++ b/samples/CameraAccessAndroid/app/src/main/AndroidManifest.xml
@@ -60,5 +60,18 @@
             android:enabled="true"
             android:exported="false"
             android:foregroundServiceType="connectedDevice" />
+
+        <!-- Quick Settings tile: one-tap launch + quick stream start -->
+        <service
+            android:name=".QuickStartTileService"
+            android:enabled="true"
+            android:exported="true"
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/quick_tile_label"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
     </application>
 </manifest>

--- a/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/MainActivity.kt
+++ b/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/MainActivity.kt
@@ -34,6 +34,9 @@ import kotlinx.coroutines.sync.withLock
 
 class MainActivity : ComponentActivity() {
   companion object {
+    const val ACTION_QUICK_START_STREAMING =
+        "com.meta.wearable.dat.externalsampleapps.cameraaccess.action.QUICK_START_STREAMING"
+
     val PERMISSIONS: Array<String> = arrayOf(
         BLUETOOTH, BLUETOOTH_CONNECT, INTERNET, RECORD_AUDIO, CAMERA,
     )
@@ -85,6 +88,19 @@ class MainActivity : ComponentActivity() {
           onRequestWearablesPermission = ::requestWearablesPermission,
       )
     }
+
+    handleQuickIntent(intent)
+  }
+
+  override fun onNewIntent(intent: android.content.Intent) {
+    super.onNewIntent(intent)
+    setIntent(intent)
+    handleQuickIntent(intent)
+  }
+
+  private fun handleQuickIntent(intent: android.content.Intent?) {
+    if (intent?.action != ACTION_QUICK_START_STREAMING) return
+    viewModel.quickStartStreaming(::requestWearablesPermission)
   }
 
   fun checkPermissions(onPermissionsGranted: () -> Unit) {

--- a/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/QuickStartTileService.kt
+++ b/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/QuickStartTileService.kt
@@ -1,0 +1,29 @@
+package com.meta.wearable.dat.externalsampleapps.cameraaccess
+
+import android.content.Intent
+import android.service.quicksettings.TileService
+
+class QuickStartTileService : TileService() {
+  override fun onClick() {
+    super.onClick()
+
+    val intent = Intent(this, MainActivity::class.java).apply {
+      action = MainActivity.ACTION_QUICK_START_STREAMING
+      addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+    }
+
+    // API 34+ supports intent directly; fallback to startActivity on older versions
+    try {
+      @Suppress("DEPRECATION")
+      startActivityAndCollapse(intent)
+    } catch (_: Throwable) {
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+      startActivity(intent)
+      @Suppress("DEPRECATION")
+      try {
+        startActivityAndCollapse(Intent())
+      } catch (_: Throwable) {
+      }
+    }
+  }
+}

--- a/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/wearables/WearablesViewModel.kt
+++ b/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/wearables/WearablesViewModel.kt
@@ -158,6 +158,23 @@ class WearablesViewModel(application: Application) : AndroidViewModel(applicatio
     _uiState.update { it.copy(isStreaming = true, isPhoneMode = true) }
   }
 
+  fun quickStartStreaming(onRequestWearablesPermission: suspend (Permission) -> PermissionStatus) {
+    val state = _uiState.value
+    if (state.isStreaming) {
+      setRecentError("Already streaming")
+      return
+    }
+    if (!state.isRegistered) {
+      setRecentError("Connect and register glasses first")
+      return
+    }
+    if (!state.hasActiveDevice) {
+      setRecentError("No active glasses device")
+      return
+    }
+    navigateToStreaming(onRequestWearablesPermission)
+  }
+
   fun navigateToDeviceSelection() {
     _uiState.update { it.copy(isStreaming = false, isPhoneMode = false) }
   }

--- a/samples/CameraAccessAndroid/app/src/main/res/values/strings.xml
+++ b/samples/CameraAccessAndroid/app/src/main/res/values/strings.xml
@@ -54,4 +54,7 @@
     <string name="getting_started_tip_led" description="Tip about capture LED">The capture LED lets others know when you\'re capturing content or going live.</string>
     <string name="getting_started_tip_photo" description="Tip about photo capture">Capture photos by tapping the camera button.</string>
     <string name="getting_started_continue" description="Continue button">Continue</string>
+
+    <!-- Quick settings tile -->
+    <string name="quick_tile_label" description="Quick Settings tile label">VisionClaw</string>
 </resources>


### PR DESCRIPTION
## Summary
This PR adds a Quick Settings tile on Android to reduce friction when starting VisionClaw streaming.

With the tile enabled, users can launch VisionClaw and trigger a quick stream start path without manually opening the app and navigating through the UI each time.

## What changed

- Added `QuickStartTileService`:
- New file:
`samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/QuickStartTileService.kt`
- Handles QS tile tap and launches `MainActivity` with a quick-start action.

- Added quick-start action handling in `MainActivity`:
- New action constant:
`ACTION_QUICK_START_STREAMING`
- Handles quick-start intents in both `onCreate` and `onNewIntent`.

- Added `quickStartStreaming(...)` in `WearablesViewModel`:
- Validates state before starting:
- not already streaming
- glasses are registered
- active device exists
- Reuses existing permission + navigation flow via `navigateToStreaming(...)`.

- Registered tile service in `AndroidManifest.xml`:
- Added `BIND_QUICK_SETTINGS_TILE` service declaration.
- Added tile icon/label metadata.

- Added UI string:
- `quick_tile_label = "VisionClaw"` in `strings.xml`.

## Why
Current flow requires repeatedly opening the app and tapping **Start streaming** manually.
This provides a much faster “one-tap” entry point and better day-to-day UX for Ray-Ban usage.

## Notes
- This PR focuses on **quick start**.
- Stop behavior remains in-app (existing controls).
- Future follow-up can add full start/stop toggle behavior in the tile itself.

## Manual test plan
1. Build/install app from this branch.
2. Add **VisionClaw** tile to Android Quick Settings.
3. Ensure glasses are connected and app is registered.
4. Tap tile:
- App should launch.
- Quick-start flow should enter streaming path.
5. Validate guardrails:
- If not registered/no active device, app shows clear error message.
