### PR TITLE
fix: add x-openclaw-scopes header to HTTP API requests

### DIFF
--- a/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/openclaw/OpenClawBridge.kt
+++ b/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/openclaw/OpenClawBridge.kt
@@ -86,6 +86,7 @@ class OpenClawBridge {
                 .get()
                 .addHeader("Authorization", "Bearer ${GeminiConfig.openClawGatewayToken}")
                 .addHeader("x-openclaw-message-channel", "glass")
+                .addHeader("x-openclaw-scopes", "operator.write")
                 .build()
 
             val response = pingClient.newCall(request).execute()
@@ -224,6 +225,7 @@ class OpenClawBridge {
             .addHeader("Content-Type", "application/json")
             .addHeader("x-openclaw-session-key", sessionKey)
             .addHeader("x-openclaw-message-channel", "glass")
+            .addHeader("x-openclaw-scopes", "operator.write")
             .build()
 
         val call = client.newCall(request)


### PR DESCRIPTION
## Problem

VisionClaw Android app fails to communicate with OpenClaw gateway via HTTP API with:

```
HTTP 403 - {"error":{"type":"forbidden","message":"missing scope: operator.write"}}
```

The gateway connection check (`checkConnection()`) may appear to succeed (since GET returns 405 which is in the 200-499 range and treated as "reachable"), but all actual task delegation via `delegateTask()` fails silently.

## Root Cause

OpenClaw gateway (2026.3.x+) enforces explicit scope declarations on HTTP API endpoints. The `POST /v1/chat/completions` endpoint requires the `x-openclaw-scopes` request header to authorize operator-level methods like `chat.send`.

Internally, the gateway calls `resolveGatewayRequestedOperatorScopes(req)` which reads scopes from the `x-openclaw-scopes` header. Without this header, scopes resolve to an empty array `[]`, and `authorizeOperatorScopesForMethod("chat.send", [])` fails because `chat.send` requires `operator.write`.

The bearer token (`Authorization: Bearer <gateway-token>`) authenticates the request but does **not** implicitly grant scopes for HTTP endpoints — scopes must be explicitly declared via the header.

## Fix

Add `x-openclaw-scopes: operator.write` header to both HTTP request sites in `OpenClawBridge.kt`:

1. **`checkConnection()`** — health-check ping request  
2. **`delegateTask()`** — chat completions POST request

WebSocket-based requests (`sendViaWebSocket` / `OpenClawEventClient`) are unaffected as they use a different auth path.

## Verification

Confirmed via curl that adding the header resolves the 403:

```bash
# Before (403)
curl -X POST -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -d '{"model":"openclaw","messages":[{"role":"user","content":"ping"}]}' \
  http://<host>:18789/v1/chat/completions

# After (200)
curl -X POST -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -H "x-openclaw-scopes: operator.write" \
  -d '{"model":"openclaw","messages":[{"role":"user","content":"ping"}]}' \
  http://<host>:18789/v1/chat/completions
# => {"choices":[{"message":{"content":"pong"}}]}
```

Also verified on device after applying the fix — OpenClaw connection status shows "Connected" and tool calls succeed.