### PR TITLE
fix: APPLICATION_ID meta-data read as Integer instead of String (fixes #13)

### DIFF
--- a/samples/CameraAccessAndroid/app/src/main/AndroidManifest.xml
+++ b/samples/CameraAccessAndroid/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         <!-- Without Developer Mode, this key will need to be set with ID from app registered in Wearables Developer Center -->
         <meta-data
             android:name="com.meta.wearable.mwdat.APPLICATION_ID"
-            android:value="0"
+            android:value="@string/mwdat_application_id"
             />
 
         <activity

--- a/samples/CameraAccessAndroid/app/src/main/res/values/strings.xml
+++ b/samples/CameraAccessAndroid/app/src/main/res/values/strings.xml
@@ -54,4 +54,7 @@
     <string name="getting_started_tip_led" description="Tip about capture LED">The capture LED lets others know when you\'re capturing content or going live.</string>
     <string name="getting_started_tip_photo" description="Tip about photo capture">Capture photos by tapping the camera button.</string>
     <string name="getting_started_continue" description="Continue button">Continue</string>
+
+    <!-- Meta DAT SDK -->
+    <string name="mwdat_application_id" translatable="false">0</string>
 </resources>


### PR DESCRIPTION
## Problem

In `AndroidManifest.xml`, the `APPLICATION_ID` meta-data is defined as:

```xml
<meta-data
    android:name="com.meta.wearable.mwdat.APPLICATION_ID"
    android:value="0"
/>
```

Android's `Bundle` interprets `"0"` as a `java.lang.Integer`, not a `String`. The Meta Wearables DAT SDK expects a `String` value via `Bundle.getString()`, which returns `null` for non-String types. This breaks the deep link construction for the registration flow, showing "Error opening link" on the Meta Stella app.

**Logcat evidence:**
```
W/Bundle: Key com.meta.wearable.mwdat.APPLICATION_ID expected String but value was a java.lang.Integer.
```

## Fix

Reference the value via a string resource instead of an inline literal:

**strings.xml:**
```xml
<string name="mwdat_application_id" translatable="false">0</string>
```

**AndroidManifest.xml:**
```xml
android:value="@string/mwdat_application_id"
```

This forces Android to treat the value as a `String`.

## Files Changed
- `app/src/main/AndroidManifest.xml`
- `app/src/main/res/values/strings.xml`

## Test plan
- [ ] "Connect my glasses" opens Meta Stella correctly (no error dialog)
- [ ] Logcat no longer shows the Integer type mismatch warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)