### PR TITLE
Fix: APPLICATION_ID meta-data read as Integer instead of String, breaking DAT registration

### DIFF
--- a/samples/CameraAccessAndroid/app/src/main/AndroidManifest.xml
+++ b/samples/CameraAccessAndroid/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         <!-- Without Developer Mode, this key will need to be set with ID from app registered in Wearables Developer Center -->
         <meta-data
             android:name="com.meta.wearable.mwdat.APPLICATION_ID"
-            android:value="0"
+            android:value="@string/mwdat_application_id"
             />
 
         <activity

--- a/samples/CameraAccessAndroid/app/src/main/res/values/strings.xml
+++ b/samples/CameraAccessAndroid/app/src/main/res/values/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" project="cameraaccess">
 
+    <!-- DAT SDK: APPLICATION_ID must be a String; inline integer literals are parsed as Integer by Android -->
+    <string name="mwdat_application_id" translatable="false">0</string>
+
     <!-- Home Screen -->
     <string name="register_button_title" description="Connect App">Connect my glasses</string>
     <string name="unregister_button_title" description="Disconnect App">Disconnect</string>


### PR DESCRIPTION
## Summary

- `android:value="0"` in `AndroidManifest.xml` is parsed by Android's `Bundle` as `java.lang.Integer`, not `String`
- The Meta Wearables DAT SDK expects a `String` for `APPLICATION_ID` — getting `null` back breaks the deep link construction for the registration flow
- Fix: move the value to a `strings.xml` resource (`<string name="mwdat_application_id" translatable="false">0</string>`) and reference it via `@string/mwdat_application_id`, which forces Android to treat it as a `String`

Fixes #13

## Test plan
- [ ] Tap "Connect my glasses" on the home screen
- [ ] Confirm the Meta Stella app opens without showing "Erreur lors de l'ouverture du lien"
- [ ] Confirm logcat no longer shows `KEY expected String but value was a java.lang.Integer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)