### PR TITLE
Fix: OpenClaw health check falsely reports connected when endpoint returns 404

### DIFF
--- a/samples/CameraAccess/CameraAccess/OpenClaw/OpenClawBridge.swift
+++ b/samples/CameraAccess/CameraAccess/OpenClaw/OpenClawBridge.swift
@@ -48,7 +48,8 @@ class OpenClawBridge: ObservableObject {
     request.setValue("glass", forHTTPHeaderField: "x-openclaw-message-channel")
     do {
       let (_, response) = try await pingSession.data(for: request)
-      if let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) {
+      if let http = response as? HTTPURLResponse,
+         (200...499).contains(http.statusCode), http.statusCode != 404 {
         connectionState = .connected
         NSLog("[OpenClaw] Gateway reachable (HTTP %d)", http.statusCode)
       } else {

--- a/samples/CameraAccess/CameraAccess/OpenClaw/OpenClawBridge.swift
+++ b/samples/CameraAccess/CameraAccess/OpenClaw/OpenClawBridge.swift
@@ -48,7 +48,7 @@ class OpenClawBridge: ObservableObject {
     request.setValue("glass", forHTTPHeaderField: "x-openclaw-message-channel")
     do {
       let (_, response) = try await pingSession.data(for: request)
-      if let http = response as? HTTPURLResponse, (200...499).contains(http.statusCode) {
+      if let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) {
         connectionState = .connected
         NSLog("[OpenClaw] Gateway reachable (HTTP %d)", http.statusCode)
       } else {


### PR DESCRIPTION
## Problem

When the `/v1/chat/completions` endpoint is disabled in `openclaw.json`, the gateway returns **404**. The health check in `checkConnection()` was accepting HTTP 200–499 as \"connected\", so a 404 silently showed a green indicator while every tool call failed.

Fixes #36

## Solution

Exclude **404 specifically** from the accepted status range, keeping the rest of 200–499 intact.

The original 200–499 range was intentional: a GET request to `/v1/chat/completions` on a healthy gateway may return a 4xx (e.g. 400 Bad Request or 405 Method Not Allowed) because the endpoint only accepts POST with a JSON body. Narrowing to 200–299 would cause a correctly-configured gateway to falsely show as \"unreachable\".

```swift
// Before (treats disabled 404 as connected)
(200...499).contains(http.statusCode)

// After (only 404 = endpoint disabled = unreachable)
(200...499).contains(http.statusCode), http.statusCode != 404
```

## Test plan
- [ ] Start OpenClaw **without** `chatCompletions.enabled: true` in `openclaw.json`
- [ ] Open the app — confirm the connection indicator shows red/unreachable (was incorrectly green before)
- [ ] Enable `chatCompletions` in `openclaw.json` and restart the gateway
- [ ] Confirm the indicator goes green (gateway returns a non-404 4xx or 2xx)
- [ ] Confirm tool calls work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)