### PR TITLE
Fix: add watchdog timer to unblock Gemini when OpenClaw tool call stalls

### DIFF
--- a/samples/CameraAccess/CameraAccess/OpenClaw/ToolCallRouter.swift
+++ b/samples/CameraAccess/CameraAccess/OpenClaw/ToolCallRouter.swift
@@ -7,6 +7,12 @@ class ToolCallRouter {
   private var consecutiveFailures = 0
   private let maxConsecutiveFailures = 3
 
+  /// Maximum time to wait for a single tool call before returning a timeout
+  /// failure to Gemini. Kept well below the URLSession 120s hard limit so the
+  /// conversation unblocks in a reasonable time even when OpenClaw is slow
+  /// (e.g. a web search that never finishes).
+  private let toolCallTimeoutSeconds: UInt64 = 60
+
   init(bridge: OpenClawBridge) {
     self.bridge = bridge
   }
@@ -38,7 +44,26 @@ class ToolCallRouter {
 
     let task = Task { @MainActor in
       let taskDesc = call.args["task"] as? String ?? String(describing: call.args)
-      let result = await bridge.delegateTask(task: taskDesc, toolName: callName)
+      let timeoutSeconds = self.toolCallTimeoutSeconds
+
+      // Race the actual delegate call against a watchdog timer. Whichever
+      // finishes first wins; the other child task is cancelled immediately.
+      let result = await withTaskGroup(of: ToolResult.self) { group in
+        group.addTask {
+          await self.bridge.delegateTask(task: taskDesc, toolName: callName)
+        }
+        group.addTask {
+          try? await Task.sleep(nanoseconds: timeoutSeconds * 1_000_000_000)
+          NSLog("[ToolCall] Watchdog fired for %@ after %llu seconds", callId, timeoutSeconds)
+          return .failure(
+            "The gateway did not respond within \(timeoutSeconds) seconds. " +
+            "Tell the user the action timed out and suggest they try again."
+          )
+        }
+        let first = await group.next()!
+        group.cancelAll()
+        return first
+      }
 
       guard !Task.isCancelled else {
         NSLog("[ToolCall] Task %@ was cancelled, skipping response", callId)


### PR DESCRIPTION
## Problem

When Gemini delegates a task that involves a slow OpenClaw skill (web search, sending a message to an external service, etc.), the conversation freezes. The UI shows **Running: execute...** and Gemini never speaks again. The underlying cause is that there is no per-call deadline — the conversation just waits for the 120s URLSession hard timeout, which is far too long for a voice interaction.

Fixes #12

## Solution

Race the `delegateTask` call against a 60-second watchdog inside `withTaskGroup`. The first child to finish wins, the other is cancelled immediately:

```swift
let result = await withTaskGroup(of: ToolResult.self) { group in
    group.addTask { await bridge.delegateTask(...) }
    group.addTask {
        try? await Task.sleep(nanoseconds: 60 * 1_000_000_000)
        return .failure("The gateway did not respond within 60 seconds. ...")
    }
    let first = await group.next()!
    group.cancelAll()
    return first
}
```

If the gateway responds in time, the watchdog task is cancelled and no behaviour changes. If the gateway stalls, Gemini receives a clear failure message after 60 seconds and can speak an apology, keeping the conversation alive.

## Test plan
- [ ] Configure OpenClaw and ask Gemini to search the web while OpenClaw is intentionally slow/unreachable
- [ ] Confirm the UI transitions from "Running: execute..." to "Failed: execute" within ~60 seconds
- [ ] Confirm Gemini speaks a timeout apology rather than hanging
- [ ] Confirm fast tool calls (< 60s) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)