### PR TITLE
Redesign in-app start screen to explain VisionClaw

### DIFF
--- a/samples/CameraAccess/CameraAccess/Views/HomeScreenView.swift
+++ b/samples/CameraAccess/CameraAccess/Views/HomeScreenView.swift
@@ -45,21 +45,35 @@ struct HomeScreenView: View {
           .aspectRatio(contentMode: .fit)
           .frame(width: 120)
 
+        VStack(spacing: 6) {
+          Text("VisionClaw")
+            .font(.system(size: 32, weight: .bold))
+            .foregroundColor(.black)
+
+          Text("A real-time AI assistant for your smart glasses. It sees what you see, hears what you say, and takes action — all hands-free.")
+            .font(.system(size: 15))
+            .foregroundColor(.gray)
+            .multilineTextAlignment(.center)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.horizontal, 12)
+        }
+        .padding(.bottom, 8)
+
         VStack(spacing: 12) {
           HomeTipItemView(
             resource: .smartGlassesIcon,
-            title: "Video Capture",
-            text: "Record videos directly from your glasses, from your point of view."
+            title: "See what you see",
+            text: "The AI looks through your glasses camera and understands the scene in front of you."
           )
           HomeTipItemView(
             resource: .soundIcon,
-            title: "Open-Ear Audio",
-            text: "Hear notifications while keeping your ears open to the world around you."
+            title: "Just talk",
+            text: "Tap the AI button and speak naturally. Ask questions and get answers out loud."
           )
           HomeTipItemView(
-            resource: .walkingIcon,
-            title: "Enjoy On-the-Go",
-            text: "Stay hands-free while you move through your day. Move freely, stay connected."
+            resource: .tapIcon,
+            title: "Take action",
+            text: "Send messages, search the web, and manage your lists by voice — powered by OpenClaw."
           )
         }
 

--- a/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/ui/HomeScreen.kt
+++ b/samples/CameraAccessAndroid/app/src/main/java/com/meta/wearable/dat/externalsampleapps/cameraaccess/ui/HomeScreen.kt
@@ -89,9 +89,21 @@ fun HomeScreen(
             tint = AppColor.DeepBlue,
             modifier = Modifier.size(80.dp * LocalDensity.current.density),
         )
+        Text(
+            text = stringResource(R.string.home_app_title),
+            fontSize = 32.sp,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            text = stringResource(R.string.home_app_tagline),
+            color = Color.Gray,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp),
+        )
         Column(
             verticalArrangement = Arrangement.spacedBy(12.dp),
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp),
         ) {
           TipItem(
               iconResId = R.drawable.smart_glasses_icon,
@@ -104,7 +116,7 @@ fun HomeScreen(
               text = stringResource(R.string.home_tip_audio),
           )
           TipItem(
-              iconResId = R.drawable.walking_icon,
+              iconResId = R.drawable.tap_icon,
               title = stringResource(R.string.home_tip_hands_title),
               text = stringResource(R.string.home_tip_hands),
           )

--- a/samples/CameraAccessAndroid/app/src/main/res/values/strings.xml
+++ b/samples/CameraAccessAndroid/app/src/main/res/values/strings.xml
@@ -6,12 +6,14 @@
     <string name="unregister_button_title" description="Disconnect App">Disconnect</string>
     <string name="stream_button_title" description="Start streaming">Start streaming</string>
     <string name="stop_stream_button_title" description="Stop streaming">Stop streaming</string>
-    <string name="home_tip_video_title" description="Tip title about video capture">Video Capture</string>
-    <string name="home_tip_audio_title" description="Tip title about audio">Open-Ear Audio</string>
-    <string name="home_tip_hands_title" description="Tip title about hands free">Enjoy On-the-Go</string>
-    <string name="home_tip_video" description="Tip about video capture">Record videos directly from your glasses, from your point of view.</string>
-    <string name="home_tip_audio" description="Tip about audio">Hear notifications while keeping your ears open to the world around you.</string>
-    <string name="home_tip_hands" description="Tip about hands free">Stay hands-free while you move through your day. Move freely, stay connected.</string>
+    <string name="home_app_title" description="App name on the home screen">VisionClaw</string>
+    <string name="home_app_tagline" description="App tagline on the home screen">A real-time AI assistant for your smart glasses. It sees what you see, hears what you say, and takes action — all hands-free.</string>
+    <string name="home_tip_video_title" description="Tip title about seeing the scene">See what you see</string>
+    <string name="home_tip_audio_title" description="Tip title about talking to the AI">Just talk</string>
+    <string name="home_tip_hands_title" description="Tip title about taking action">Take action</string>
+    <string name="home_tip_video" description="Tip about seeing the scene">The AI looks through your glasses camera and understands the scene in front of you.</string>
+    <string name="home_tip_audio" description="Tip about talking to the AI">Tap the AI button and speak naturally. Ask questions and get answers out loud.</string>
+    <string name="home_tip_hands" description="Tip about taking action">Send messages, search the web, and manage your lists by voice — powered by OpenClaw.</string>
     <string name="home_redirect_message" description="Redirect message">You\'ll be redirected to the Meta AI app to confirm your connection.</string>
 
     <!-- Stream Screen -->


### PR DESCRIPTION
## What & why

On launch, the home screen showed generic Meta-glasses tips left over from
the original sample app — "Video Capture", "Open-Ear Audio", "Enjoy On-the-Go".
None of it tells a first-time user that VisionClaw is an AI assistant you
see-with and talk to, or how to start using it.

This redesigns the start screen on both iOS and Android so the app explains
itself on launch.

## Changes
- Add the app name (VisionClaw) and a one-line tagline under the icon.
- Rewrite the three tips to explain what it does and how to use it:
  - See what you see — the AI looks through your glasses camera.
  - Just talk — tap the AI button and speak naturally.
  - Take action — send messages, search, manage lists by voice (via OpenClaw).
- Use the existing tap icon for the new "Take action" tip.

Existing buttons and the registration flow are unchanged.

## Files
- iOS: samples/CameraAccess/.../Views/HomeScreenView.swift
- Android: samples/CameraAccessAndroid/.../ui/HomeScreen.kt + res/values/strings.xml

Layout/strings only — no behavior changes, no new assets.
